### PR TITLE
3つ解消

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,9 +1,17 @@
+# backend/tasks.py
 from celery import Celery
 from python_to_translation import run_translation
 
-celery = Celery('tasks', broker='redis://redis:6379/0')
+# ← broker に加えて backend を指定
+celery = Celery(
+    'tasks',
+    broker='redis://redis:6379/0',
+    backend='redis://redis:6379/0'
+)
 
 @celery.task(bind=True)
 def translate_task(self, input_path, params):
+    # run_translation 内で発生した例外はここでキャッチされ
+    # AsyncResult に traceback とともに格納されます
     return run_translation(input_path, **params)
 

--- a/backend/translation_app.py
+++ b/backend/translation_app.py
@@ -1,4 +1,8 @@
-from flask import Flask, request, jsonify, send_file, send_from_directory
+# backend/translation_app.py
+from flask import (
+    Flask, request, jsonify,
+    send_file, send_from_directory, redirect
+)
 from tasks import translate_task
 import os, json
 
@@ -6,12 +10,16 @@ app = Flask(__name__)
 UPLOAD = 'uploads'
 os.makedirs(UPLOAD, exist_ok=True)
 
-# 静的ファイル配信
+# 静的 UI を配信
+@app.route('/', methods=['GET'])
+def index():
+    return send_from_directory('frontend', 'index.html')
+
 @app.route('/frontend/<path:filename>')
 def frontend_static(filename):
     return send_from_directory('frontend', filename)
 
-# 翻訳ジョブ受付
+# POST のみ許可
 @app.route('/api/translate', methods=['POST'])
 def api_translate():
     f = request.files.get('file')
@@ -21,23 +29,26 @@ def api_translate():
 
     path = os.path.join(UPLOAD, f.filename)
     f.save(path)
-
-    # 数値型・真偽値型への変換
-    for k in ['rpm', 'chunk', 'max_retry', 'backoff_base']:
+    # 型変換
+    for k in ['rpm','chunk','max_retry','backoff_base']:
         if k in params:
             try:
                 params[k] = int(params[k])
             except ValueError:
-                return jsonify(error=f'invalid integer for {k}'), 400
-    for k in ['verbose_prompt', 'verbose_resp', 'verbose_write']:
-        params[k] = params.get(k, 'false').lower() == 'true'
+                return jsonify(error=f'Invalid integer for {k}'), 400
+    for k in ['verbose_prompt','verbose_resp','verbose_write']:
+        params[k] = params.get(k,'false').lower()=='true'
     params['api_key'] = params['api_key']
 
     job = translate_task.delay(path, params)
     return jsonify(job_id=job.id), 202
 
-# ジョブステータス取得
-@app.route('/api/status/<job_id>')
+# 万が一 GET でたたかれたらルートへリダイレクト
+@app.route('/api/translate', methods=['GET'])
+def api_translate_get():
+    return redirect('/')
+
+@app.route('/api/status/<job_id>', methods=['GET'])
 def api_status(job_id):
     res = translate_task.AsyncResult(job_id)
     payload = {'status': res.status}
@@ -45,8 +56,7 @@ def api_status(job_id):
         payload['error'] = str(res.result)
     return jsonify(payload)
 
-# 結果ファイル取得
-@app.route('/api/result/<job_id>')
+@app.route('/api/result/<job_id>', methods=['GET'])
 def api_result(job_id):
     res = translate_task.AsyncResult(job_id)
     if res.status == 'SUCCESS':
@@ -54,6 +64,5 @@ def api_result(job_id):
     return jsonify(error='processing'), 202
 
 if __name__ == '__main__':
-    # 本番は Gunicorn 等で起動する想定ですが、開発用にこのままでもOK
     app.run(host='0.0.0.0', port=5000)
 


### PR DESCRIPTION
Celery が結果バックエンドに Redis を使うようになり (DisabledBackend のエラー解消)

Gemini 応答 のパース失敗をキャッチして明示的に例外を投げるようになり (JSONDecodeError の原因把握)

GET /api/translate にアクセスしたときもちゃんと 404 ではなくトップページにリダイレクトする (405 対策)